### PR TITLE
fix: wrong xPYT allowance check in UniswapV3Swapper::swapNytToUnderly…

### DIFF
--- a/src/uniswap-v3/UniswapV3Swapper.sol
+++ b/src/uniswap-v3/UniswapV3Swapper.sol
@@ -279,7 +279,7 @@ contract UniswapV3Swapper is Swapper, IUniswapV3SwapCallback {
         // burn xPYT & NYT into underlying
         if (
             args.xPYT.allowance(address(this), address(args.gate)) <
-            tokenAmountOut
+            args.xPYT.previewWithdraw(tokenAmountOut)
         ) {
             args.xPYT.safeApprove(address(args.gate), type(uint256).max);
         }
@@ -370,7 +370,7 @@ contract UniswapV3Swapper is Swapper, IUniswapV3SwapCallback {
         // burn xPYT & NYT into underlying
         if (
             args.xPYT.allowance(address(this), address(args.gate)) <
-            tokenAmountOut
+            args.xPYT.previewWithdraw(tokenAmountOut)
         ) {
             args.xPYT.safeApprove(address(args.gate), type(uint256).max);
         }


### PR DESCRIPTION
…ing and UniswapV3Swapper::swapXpytToUnderlying